### PR TITLE
footer now sticks to bottom of page

### DIFF
--- a/client/layout/layout.css
+++ b/client/layout/layout.css
@@ -1,0 +1,9 @@
+body {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+main {
+  flex: 1 0 auto;
+}

--- a/client/layout/layout.html
+++ b/client/layout/layout.html
@@ -2,11 +2,17 @@
   <head>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
   </head>
-  <header>
-    {{> navigation}}
-  </header>
-  <div class="container">
-    {{> yield}}
-  </div>
-  {{> footer}}
+  <body>
+    <header>
+      {{> navigation}}
+    </header>
+    <main>
+      <div class="container">
+        {{> yield}}
+      </div>
+    </main>
+    <footer>
+      {{> footer}}
+    </footer>
+  </body>
 </template>


### PR DESCRIPTION
if there is less content than the browser window
height, then the footer will be stuck to the bottom
of the browser window.

if there is more content, then the footer will be
stuck to the bottom of the page's content.

This is to tackle issue #49.
